### PR TITLE
Fix empty SSL XML elements in the websocket plugin

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Launch 1.x
 
+### Ignition Launch 1.x.x (2020-xx-xx)
+
+1. Fix empty SSL xml elements in the websocket plugin.
+    * [Pull Request 35](https://github.com/ignitionrobotics/ign-launch/pull/35)
+
 ### Ignition Launch 1.7.0 (2020-06-16)
 
 1. Added SSL to websocket server.

--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,7 @@
 ### Ignition Launch 1.x.x (2020-xx-xx)
 
 1. Fix empty SSL xml elements in the websocket plugin.
-    * [Pull Request 35](https://github.com/ignitionrobotics/ign-launch/pull/35)
+    * [Pull Request 36](https://github.com/ignitionrobotics/ign-launch/pull/36)
 
 ### Ignition Launch 1.7.0 (2020-06-16)
 

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -214,13 +214,13 @@ bool WebsocketServer::Load(const tinyxml2::XMLElement *_elem)
     // Get the ssl cert file, if present.
     const tinyxml2::XMLElement *certElem =
       elem->FirstChildElement("cert_file");
-    if (certElem)
+    if (certElem && certElem->GetText())
       sslCertFile = certElem->GetText();
 
     // Get the ssl private key file, if present.
     const tinyxml2::XMLElement *keyElem =
       elem->FirstChildElement("private_key_file");
-    if (keyElem)
+    if (keyElem && keyElem->GetText())
       sslPrivateKeyFile = keyElem->GetText();
   }
 


### PR DESCRIPTION
This PR makes sure the the tinyxml2 `GetText` calls returns valid pointers. Without this check, the following would crash

```
<ssl>
      <cert_file></cert_file>
      <private_key_file></private_key_file>
</ssl>
```

Signed-off-by: Nate Koenig <nate@openrobotics.org>