### PR TITLE
Improve websocket performance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Ignition Launch 1.x
 
+### Ignition Launch 1.x.x (2020-xx-xx)
+
+1. Fix empty SSL xml elements in the websocket plugin.
+    * [Pull Request 35](https://github.com/ignitionrobotics/ign-launch/pull/35)
+
 ### Ignition Launch 1.7.0 (2020-06-16)
 
 1. Added SSL to websocket server.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,9 @@
 
 ### Ignition Launch 1.x.x (2020-xx-xx)
 
+1. Improve websocket performance by throttling the busy loop.
+    * [Pull Request 36](https://github.com/ignitionrobotics/ign-launch/pull/36)
+
 1. Fix empty SSL xml elements in the websocket plugin.
     * [Pull Request 35](https://github.com/ignitionrobotics/ign-launch/pull/35)
 

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -214,13 +214,13 @@ bool WebsocketServer::Load(const tinyxml2::XMLElement *_elem)
     // Get the ssl cert file, if present.
     const tinyxml2::XMLElement *certElem =
       elem->FirstChildElement("cert_file");
-    if (certElem)
+    if (certElem && certElem->GetText())
       sslCertFile = certElem->GetText();
 
     // Get the ssl private key file, if present.
     const tinyxml2::XMLElement *keyElem =
       elem->FirstChildElement("private_key_file");
-    if (keyElem)
+    if (keyElem && keyElem->GetText())
       sslPrivateKeyFile = keyElem->GetText();
   }
 

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -355,7 +355,7 @@ void WebsocketServer::Run()
     // Wait for (1/60) seconds or an event.
     std::unique_lock<std::mutex> lock(this->runMutex);
     this->runConditionVariable.wait_for(lock,
-        0.0166s, [&]{return !this->run || this->messageCount <= 0;});
+        0.0166s, [&]{return !this->run || this->messageCount > 0;});
   }
 }
 

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -85,7 +85,6 @@ int rootCallback(struct lws *_wsi,
     case LWS_CALLBACK_SERVER_WRITEABLE:
       {
         std::lock_guard<std::mutex> lock(self->connections[fd]->mutex);
-        //while (!self->connections[fd]->buffer.empty())
         if (!self->connections[fd]->buffer.empty())
         {
           int msgSize = self->connections[fd]->len.front();
@@ -101,6 +100,8 @@ int rootCallback(struct lws *_wsi,
           }
           else
           {
+            std::scoped_lock<std::mutex> runLock(self->runMutex);
+            self->messageCount--;
             // Only pop the message if it was sent successfully.
             self->connections[fd]->buffer.pop_front();
             self->connections[fd]->len.pop_front();
@@ -136,9 +137,16 @@ WebsocketServer::WebsocketServer()
 /////////////////////////////////////////////////
 WebsocketServer::~WebsocketServer()
 {
-  if (this->thread && this->run)
+  if (this->thread)
   {
-    this->run = false;
+    {
+      std::scoped_lock<std::mutex> lock(this->runMutex);
+      if (this->run)
+      {
+        this->run = false;
+        this->runConditionVariable.notify_all();
+      }
+    }
     this->thread->join();
   }
   this->thread = nullptr;
@@ -322,6 +330,10 @@ void WebsocketServer::QueueMessage(Connection *_connection,
     std::lock_guard<std::mutex> lock(_connection->mutex);
     _connection->buffer.push_back(std::move(buf));
     _connection->len.push_back(_size);
+
+    std::scoped_lock<std::mutex> runLock(this->runMutex);
+    this->messageCount++;
+    this->runConditionVariable.notify_all();
   }
   else
   {
@@ -332,9 +344,19 @@ void WebsocketServer::QueueMessage(Connection *_connection,
 //////////////////////////////////////////////////
 void WebsocketServer::Run()
 {
-  uint64_t timeout = 50;
+  using namespace std::chrono_literals;
+
   while (this->run)
-    lws_service(this->context, timeout);
+  {
+    // The second parameter is a timeout that is no longer used by
+    // libwebsockets.
+    lws_service(this->context, 0);
+
+    // Wait for (1/60) seconds or an event.
+    std::unique_lock<std::mutex> lock(this->runMutex);
+    this->runConditionVariable.wait_for(lock,
+        0.0166s, [&]{return !this->run || this->messageCount <= 0;});
+  }
 }
 
 //////////////////////////////////////////////////

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -191,6 +191,16 @@ namespace ignition
       /// connections that have subscribed to the topic.
       public: std::map<std::string, std::set<int>> topicConnections;
 
+      /// \brief Run loop mutex.
+      public: std::mutex runMutex;
+
+      /// \brief Run loop condition variable.
+      public: std::condition_variable runConditionVariable;
+
+      /// \brief Number of pending messages. This is used to throttle the
+      /// run loop.
+      public: int messageCount{0};
+
       /// \brief Time of last publication for each subscribed topic. The key
       /// is the topic name and the value the time of last publication.
       /// \sa publishPeriod.

--- a/plugins/websocket_server/index.html
+++ b/plugins/websocket_server/index.html
@@ -15,7 +15,7 @@
     // Make sure to also disable SSL and authentication in the
     // websocket_server plugin.
     var ign = new Ignition({
-      url: 'wss://localhost:9002',
+      url: 'ws://localhost:9002',
       key: "auth_key"
     });
 


### PR DESCRIPTION
The `::Run` loop was not throttled. This would peg a process without accomplishing meaningful work.

This PR adds some logic to throttle the `::Run` loop using a default wait time and notifications based on whether there is data to transmit.

Signed-off-by: Nate Koenig <nate@openrobotics.org>