### PR TITLE
Add Fuel World Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ ign_find_package(ignition-math6 REQUIRED)
 set(IGN_MATH_MAJOR_VER ${ignition-math6_VERSION_MAJOR})
 
 #--------------------------------------
+# Find ignition-fuel_tools3
+ign_find_package(ignition-fuel_tools3 REQUIRED)
+set(IGN_FUEL_TOOLS_VER ${ignition-fuel_tools3_VERSION_MAJOR})
+
+#--------------------------------------
 # Find ignition-gui
 ign_find_package(ignition-gui2 REQUIRED)
 set(IGN_GUI_MAJOR_VER ${ignition-gui2_VERSION_MAJOR})

--- a/plugins/gazebo_server/GazeboServer.cc
+++ b/plugins/gazebo_server/GazeboServer.cc
@@ -16,12 +16,11 @@
 */
 
 #include <ignition/common/Console.hh>
-#include <sdf/sdf.hh>
 #include <ignition/fuel_tools/FuelClient.hh>
 #include <ignition/fuel_tools/ClientConfig.hh>
 #include <ignition/fuel_tools/Result.hh>
 #include <ignition/fuel_tools/WorldIdentifier.hh>
-
+#include <sdf/sdf.hh>
 
 #include "GazeboServer.hh"
 
@@ -95,17 +94,13 @@ bool GazeboServer::Load(const tinyxml2::XMLElement *_elem)
 
   // Get the world file
   elem = _elem->FirstChildElement("world_file");
-  ignwarn << "in load" << std::endl;
   if (elem)
   {
-    ignwarn << "elem text is " << elem->GetText() << std::endl;
     std::string current = elem->GetText();
 
     // If the world file is not a file, assume it is a fuel world
     if (!ignition::common::isFile(current))
     {
-      // TODO here download, check cached, find sdf file
-      
       std::string path;
       std::string fileName = "";
       ignition::fuel_tools::ServerConfig server;
@@ -116,20 +111,17 @@ bool GazeboServer::Load(const tinyxml2::XMLElement *_elem)
   
       if (fuelClient.CachedWorld(ignition::common::URI(current), path))
       {
-        ignwarn << "Cached - path is " << path << std::endl;
         fileName = findResourceSdf(path);
       } 
-      
-      ignition::fuel_tools::Result result = fuelClient.DownloadWorld(ignition::common::URI(current), path);
-      
-      if (result)
+      else if (ignition::fuel_tools::Result result =
+          fuelClient.DownloadWorld(ignition::common::URI(current), path);
+          result)
       {
-        ignwarn << "Downloaded - path is " << path << std::endl;
         fileName = findResourceSdf(path);
       } 
       else
       {
-        std::cout << "Download failed because " << result.ReadableResult()
+        ignwarn << "Fuel world download failed because " << result.ReadableResult()
             << std::endl;
       }
       serverConfig.SetSdfFile(fileName);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ target_link_libraries(${PROJECT_LIBRARY_TARGET_NAME}
   PUBLIC
     ignition-plugin${IGN_PLUGIN_MAJOR_VER}::loader
     ignition-plugin${IGN_PLUGIN_MAJOR_VER}::register
+    ignition-fuel_tools${IGN_FUEL_TOOLS_VER}::ignition-fuel_tools${IGN_FUEL_TOOLS_VER}
     TINYXML2::TINYXML2
   PRIVATE
     ignition-common${IGN_COMMON_MAJOR_VER}::ignition-common${IGN_COMMON_MAJOR_VER}

--- a/src/Manager.cc
+++ b/src/Manager.cc
@@ -34,9 +34,14 @@
 #include <vector>
 
 #include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
 #include <ignition/common/SignalHandler.hh>
 #include <ignition/common/SystemPaths.hh>
 #include <ignition/plugin/Loader.hh>
+#include <ignition/fuel_tools/FuelClient.hh>
+#include <ignition/fuel_tools/ClientConfig.hh>
+#include <ignition/fuel_tools/Result.hh>
+#include <ignition/fuel_tools/WorldIdentifier.hh>
 
 #include "ignition/launch/config.hh"
 #include "ignition/launch/Plugin.hh"


### PR DESCRIPTION
Adds support for loading fuel worlds via the `world_file` tag in an `.ign` launch file.

To test, simply add a fuel URL, ie, `https://staging-fuel.ignitionrobotics.org/1.0/gmas/worlds/ShapesClone` to the `world_file` tag in an ign launch file

See also https://github.com/ignitionrobotics/ign-gazebo/pull/274