### PR TITLE
Add PKGCONFIG information to ignition-tools ign_find_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,9 @@ set(IGN_PLUGIN_MAJOR_VER ${ignition-plugin1_VERSION_MAJOR})
 
 #--------------------------------------
 # Find ignition-tools
-ign_find_package(ignition-tools REQUIRED)
+ign_find_package(ignition-tools
+  REQUIRED
+  PKGCONFIG "ignition-tools")
 
 #--------------------------------------
 # Find ignition-transport


### PR DESCRIPTION
Try to clean up warning about the use of ignition-tools in the `ign_find_package` call.