### PR TITLE
Websocket server metrics endpoint

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 ## Ignition Launch 1.x
 
+### Ignition Launch 1.9.0 (2020-08-10)
+
+1. Added HTTP handling support to websocket server and a metrics HTTP endpoint 
+   to monitor websocket server status.
+   * [Pull Request 49](https://github.com/ignitionrobotics/ign-launch/pull/49)
+
 ### Ignition Launch 1.8.0 (2020-07-28)
 
 1. Added `<max_connections>` to the websocket server that supports

--- a/examples/websocket.ign
+++ b/examples/websocket.ign
@@ -1,8 +1,8 @@
 <?xml version='1.0'?>
 <ignition version='1.0'>
 
-  <!-- Load a joystick plugin that will read from a device and output to a
-       topic -->
+  <!-- Load a websocket server that provides access to Ignition Transport
+       topics through websockets.-->
   <plugin name="ignition::launch::WebsocketServer"
           filename="libignition-launch-websocket-server.so">
     <publication_hz>30</publication_hz>

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -175,7 +175,7 @@ int httpCallback(struct lws *_wsi,
       break;
   }
 
-  return 0;
+  return -1;
 }
 
 int rootCallback(struct lws *_wsi,

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -164,13 +164,13 @@ int httpCallback(struct lws *_wsi,
         unsigned char buf[buflen + LWS_PRE];
         int n;
         n = snprintf(reinterpret_cast<char *>(buf), buflen, format,
-                     conns.c_str());
+            conns.c_str());
         // Check that no characters were discarded
         if (n - int(buflen) > 0)
         {
           ignwarn << "Discarded "
-                  << n - int(buflen)
-                  << "characters when preparing metrics.\n";
+            << n - int(buflen)
+            << "characters when preparing metrics.\n";
         }
 
         // Write response headers
@@ -201,7 +201,7 @@ int httpCallback(struct lws *_wsi,
 }
 
 /// \brief Default request event handler. All requests that do not explicitly
-/// specify a protocol name are hanlded by this function.
+/// specify a protocol name are handled by this function.
 /// \param _wsi lws connection.
 /// \param _reason lws event. Reason for the call.
 /// \param _user Pointer to per-session user data allocated by library.


### PR DESCRIPTION
This PR adds a `/metrics` HTTP endpoint to the websocket server using libwebsockets HTTP capabilities.

The `/metrics` endpoint currently returns the number of active websocket connections. It will be used to monitor and scale websocket server deployments.

Note: No new `lws` protocols were added to support HTTP. Instead, the `LWS_CALLBACK_HTTP` event is first handled by `rootCallback` and delegated to `httpCallback`. It was implemented this way because HTTP requests do not provide protocol names and end up defaulting to `rootCallback`.