### PR TITLE
⬆️  Bump main to 4.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-launch3 VERSION 3.0.0)
+project(ignition-launch4 VERSION 4.0.0)
 
 #============================================================================
 # Find ignition-cmake


### PR DESCRIPTION
The `ign-launch3` branch was created off `main` for the Dome release.

Now bumping `main` to version 4 so it may receive breaking changes.