### PR TITLE
⬆️  1.10.1 🏁

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-launch1 VERSION 1.10.0)
+project(ignition-launch1 VERSION 1.10.1)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,13 @@
 ## Ignition Launch 1.x
 
-### Ignition Launch 1.X.X (20XX-XX-XX)
+### Ignition Launch 1.10.1 (2020-12-23)
+
+1. Fix codecheck
+   * [Pull Request 67](https://github.com/ignitionrobotics/ign-launch/pull/67)
+   * [Pull Request 70](https://github.com/ignitionrobotics/ign-launch/pull/70)
+
+1. Fix race condition in websocket server
+   * [Pull Request 68](https://github.com/ignitionrobotics/ign-launch/pull/68)
 
 ### Ignition Launch 1.10.0 (2020-09-25)
 


### PR DESCRIPTION
Preparing for a last major version 1 release before Blueprint EOLs in 8 days.

Comparison to 1.10.0:

https://github.com/ignitionrobotics/ign-launch/compare/ignition-launch_1.10.0...ign-launch1

There are no PRs open against `ign-launch1`.