### PR TITLE
Fix env parsing by placing it before executable parsing

### DIFF
--- a/src/Manager.cc
+++ b/src/Manager.cc
@@ -521,6 +521,9 @@ bool ManagerPrivate::ParseConfig(const std::string &_config)
     ignerr << "Invalid config file,m issing <ignition> element\n";
     return false;
   }
+  // Keep the environment variables in memory. See manpage for putenv.
+  this->envs = this->ParseEnvs(root);
+  this->SetEnvs(this->envs);
 
   // Parse and create all the <executable> elements.
   this->ParseExecutables(root);
@@ -528,10 +531,6 @@ bool ManagerPrivate::ParseConfig(const std::string &_config)
   // Parse and create all the <executable_wrapper> elements.
   if (this->master)
     this->ParseExecutableWrappers(root);
-
-  // Keep the environment variables in memory. See manpage for putenv.
-  this->envs = this->ParseEnvs(root);
-  this->SetEnvs(this->envs);
 
   // Parse and create all the <plugin> elements.
   if (this->master)

--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -17,7 +17,45 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
+
+#include <ignition/utilities/ExtraTestMacros.hh>
+
+#include <sys/stat.h>
+
 #include "Manager.hh"
+
+static constexpr char kTestScriptPath[] = "/tmp/ign-launch.sh";
+
+/////////////////////////////////////////////////
+bool RemoveTestScript()
+{
+  // Remove the file if it already exists
+  if (ignition::common::isFile(kTestScriptPath))
+  {
+    if (!ignition::common::removeFile(kTestScriptPath))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool WriteTestScript()
+{
+  if (!RemoveTestScript())
+    return false;
+
+  // Write a simple script and mark it executable
+  std::ofstream ofs(kTestScriptPath);
+  ofs << R"(#!/usr/bin/env bash
+echo $TEST_VAR
+touch $TEST_VAR
+)";
+  chmod(kTestScriptPath, S_IRWXU);
+  return true;
+}
 
 /////////////////////////////////////////////////
 TEST(Ignition_TEST, RunEmptyConfig)
@@ -79,6 +117,73 @@ TEST(Ignition_TEST, RunLs)
   // We should be able to run the ls command. This does not check the
   // output.
   EXPECT_TRUE(mgr.RunConfig(config));
+}
+
+
+/////////////////////////////////////////////////
+TEST(Ignition_TEST, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPre))
+{
+  // Test that environment is applied regardless of order
+  std::string testPath = "/tmp/ign-launch-env-test-pre";
+
+  if (ignition::common::isFile(testPath))
+  {
+    ASSERT_TRUE(ignition::common::removeFile(testPath));
+  }
+
+  ASSERT_TRUE(WriteTestScript());
+
+  std::string config = R"(
+<ignition version='1.0'>
+  <env>
+    <name>TEST_VAR</name>
+    <value>)" + testPath + R"(</value>
+  </env>
+  <executable name='touch'>
+    <command>/tmp/ign-launch.sh</command>
+  </executable>
+</ignition>
+)";
+
+  ignition::launch::Manager mgr;
+
+  EXPECT_TRUE(mgr.RunConfig(config));
+  EXPECT_TRUE(ignition::common::isFile(testPath));
+  EXPECT_TRUE(ignition::common::removeFile(testPath));
+  EXPECT_TRUE(RemoveTestScript());
+}
+
+/////////////////////////////////////////////////
+TEST(Ignition_TEST, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPost))
+{
+  // Test that environment is applied regardless of order
+  std::string testPath = "/tmp/ign-launch-env-test-post";
+
+  if (ignition::common::isFile(testPath))
+  {
+    ASSERT_TRUE(ignition::common::removeFile(testPath));
+  }
+
+  ASSERT_TRUE(WriteTestScript());
+
+  std::string config = R"(
+<ignition version='1.0'>
+  <executable name='touch'>
+    <command>/tmp/ign-launch.sh</command>
+  </executable>
+  <env>
+    <name>TEST_VAR</name>
+    <value>)" + testPath + R"(</value>
+  </env>
+</ignition>
+)";
+
+  ignition::launch::Manager mgr;
+
+  EXPECT_TRUE(mgr.RunConfig(config));
+  EXPECT_TRUE(ignition::common::isFile(testPath));
+  EXPECT_TRUE(ignition::common::removeFile(testPath));
+  EXPECT_TRUE(RemoveTestScript());
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
The application of environment variables in launch files was broken due to incorrect order of operations. Environment variables need to be set before forking processes. This fixes the problem.

Example:

```
<ignition version='1.0'>
  <env>
    <name>IGN_TRANSPORT_TOPIC_STATISTICS</name>
    <value>1</value>
  </env>

  <plugin name="ignition::launch::GazeboServer" filename="libignition-launch-gazebo.so">...</plugin>
  
  <executable_wrapper>
    <plugin name="ignition::launch::GazeboGui" filename="libignition-launch-gazebogui.so">...</plugin>
  </executable_wrapper>
```
In the above example, the `GazeboServer` would have `IGN_TRANSPORT_TOPIC_STATISTICS=1` but `GazeboGui` would have `IGN_TRANSPORT_TOPIC_STATISTICS = undefined`.

This is a behavior change from the currently release code, but this fix is fairly important.

Signed-off-by: Nate Koenig <nate@openrobotics.org>