### PR TITLE
Add tests to #81

### DIFF
--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -17,7 +17,45 @@
 
 #include <gtest/gtest.h>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Filesystem.hh>
+
+#include <ignition/utilities/ExtraTestMacros.hh>
+
+#include <sys/stat.h>
+
 #include "Manager.hh"
+
+static const std::string kTestScriptPath = "/tmp/ign-launch.sh";
+
+/////////////////////////////////////////////////
+bool RemoveTestScript()
+{
+  // Remove the file if it already exists
+  if (ignition::common::isFile(kTestScriptPath))
+  {
+    if (!ignition::common::removeFile(kTestScriptPath))
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+/////////////////////////////////////////////////
+bool WriteTestScript()
+{
+  if (!RemoveTestScript())
+    return false;
+
+  // Write a simple script and mark it executable
+  std::ofstream ofs(kTestScriptPath);
+  ofs << R"(#!/usr/bin/env bash
+echo $TEST_VAR
+touch $TEST_VAR
+)";
+  chmod(kTestScriptPath.c_str(), S_IRWXU);
+  return true;
+}
 
 /////////////////////////////////////////////////
 TEST(Ignition_TEST, RunEmptyConfig)
@@ -79,6 +117,73 @@ TEST(Ignition_TEST, RunLs)
   // We should be able to run the ls command. This does not check the
   // output.
   EXPECT_TRUE(mgr.RunConfig(config));
+}
+
+
+/////////////////////////////////////////////////
+TEST(Ignition_TEST, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPre))
+{
+  // Test that environment is applied regardless of order
+  std::string testPath = "/tmp/ign-launch-env-test-pre";
+
+  if (ignition::common::isFile(testPath))
+  {
+    ASSERT_TRUE(ignition::common::removeFile(testPath));
+  }
+
+  ASSERT_TRUE(WriteTestScript());
+
+  std::string config = R"(
+<ignition version='1.0'>
+  <env>
+    <name>TEST_VAR</name>
+    <value>)" + testPath + R"(</value>
+  </env>
+  <executable name='touch'>
+    <command>/tmp/ign-launch.sh</command>
+  </executable>
+</ignition>
+)";
+
+  ignition::launch::Manager mgr;
+
+  EXPECT_TRUE(mgr.RunConfig(config));
+  EXPECT_TRUE(ignition::common::isFile(testPath));
+  EXPECT_TRUE(ignition::common::removeFile(testPath));
+  EXPECT_TRUE(RemoveTestScript());
+}
+
+/////////////////////////////////////////////////
+TEST(Ignition_TEST, IGN_UTILS_TEST_DISABLED_ON_WIN32(RunEnvPost))
+{
+  // Test that environment is applied regardless of order
+  std::string testPath = "/tmp/ign-launch-env-test-post";
+
+  if (ignition::common::isFile(testPath))
+  {
+    ASSERT_TRUE(ignition::common::removeFile(testPath));
+  }
+
+  ASSERT_TRUE(WriteTestScript());
+
+  std::string config = R"(
+<ignition version='1.0'>
+  <executable name='touch'>
+    <command>/tmp/ign-launch.sh</command>
+  </executable>
+  <env>
+    <name>TEST_VAR</name>
+    <value>)" + testPath + R"(</value>
+  </env>
+</ignition>
+)";
+
+  ignition::launch::Manager mgr;
+
+  EXPECT_TRUE(mgr.RunConfig(config));
+  EXPECT_TRUE(ignition::common::isFile(testPath));
+  EXPECT_TRUE(ignition::common::removeFile(testPath));
+  EXPECT_TRUE(RemoveTestScript());
 }
 
 /////////////////////////////////////////////////

--- a/src/Manager_TEST.cc
+++ b/src/Manager_TEST.cc
@@ -25,7 +25,7 @@
 
 #include "Manager.hh"
 
-static const std::string kTestScriptPath = "/tmp/ign-launch.sh";
+static constexpr char kTestScriptPath[] = "/tmp/ign-launch.sh";
 
 /////////////////////////////////////////////////
 bool RemoveTestScript()
@@ -53,7 +53,7 @@ bool WriteTestScript()
 echo $TEST_VAR
 touch $TEST_VAR
 )";
-  chmod(kTestScriptPath.c_str(), S_IRWXU);
+  chmod(kTestScriptPath, S_IRWXU);
   return true;
 }
 


### PR DESCRIPTION
This adds a simple check to verify that the env directives apply
to everything in the ignition namespace, as fixed in #81.

The test itself is a bit of a workaround. We don't have a mechanism
for checking the manager output, and executable command directives
cannot expand environment variables.

This writes a script that is executed by the test to verify that a
file specified by an environment variable is touch-ed

Signed-off-by: Michael Carroll <michael@openrobotics.org>