### PR TITLE
Treat IGN_LAUNCH_CONFIG_PATH as a path list.

### DIFF
--- a/Migration.md
+++ b/Migration.md
@@ -5,4 +5,11 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Ignition Launch 2.2.2
+
+- Environment variable `IGN_LAUNCH_CONFIG_PATH` started to be treated as a path
+  list (colon-separated on Linux, semicolon-separated on Windows). Before, only
+  a single path could be set here, and setting a path list would break the whole
+  launch file lookup functionality.
+
 ## Ignition Launch 0.X to N.M

--- a/src/cmdlaunch.rb.in
+++ b/src/cmdlaunch.rb.in
@@ -159,25 +159,34 @@ class Cmd
       end
 
       if options.key?('file')
-        # Check if the passed in file exists. 
+        # Check if the passed in file exists.
+        path = ''
         if File.exists?(options['file'])
           path = options['file']
+        end
         # If not, then first check the IGN_LAUNCH_CONFIG_PATH environment
         # variable, then the configuration path from the launch library.
-        else
+        if path.empty?
           configPathEnv = ENV['IGN_LAUNCH_CONFIG_PATH']
-          if !configPathEnv.nil? &&
-              File.exists?(File.join(configPathEnv, options['file']))
-            path = File.join(configPathEnv, options['file'])
-          # get the configuration path from the launch library.
-          else
-            Importer.extern 'char *configPath()'
-            path = File.join(Importer.configPath().to_s, options['file'])
-            if !File.exists?(path) 
-              puts "Unable to find file " + options['file']
-              exit(-1)
+          if !configPathEnv.nil?
+            configPaths = configPathEnv.split(File::PATH_SEPARATOR)
+            for configPath in configPaths
+              filePath = File.join(configPath, options['file'])
+              if File.exists?(filePath)
+                path = filePath
+                break
+              end
             end
           end
+        end
+        # get the configuration path from the launch library.
+        if path.empty?
+          Importer.extern 'char *configPath()'
+          path = File.join(Importer.configPath().to_s, options['file'])
+        end
+        if path.empty? or !File.exists?(path)
+          puts "Unable to find file " + options['file']
+          exit(-1)
         end
 
         # ERB parse the file with the variable bindings

--- a/tutorials.md.in
+++ b/tutorials.md.in
@@ -6,6 +6,8 @@ Ignition @IGN_DESIGNATION_CAP@ library and how to use the library effectively.
 
 **Tutorials**
 
+1. \subpage basics "Ignition launch tutorial"
+
 ## License
 
 The code associated with this documentation is licensed under an [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0).

--- a/tutorials/tutorial.md
+++ b/tutorials/tutorial.md
@@ -1,4 +1,4 @@
-# Ignition launch tutorial
+\page basics Ignition launch tutorial
 
 Ignition Launch is used to run and manage plugins and programs. A configuration script can be used to specify which programs and plugins to execute. Alternatively, individual programs and plugins can be run from the command line.
 
@@ -55,3 +55,17 @@ The [worldName] command line argument is optional. If left blank, or not specifi
 Example to load `the shapes.sdf`:
 
 `ign launch gazebo_plugins.ign worldName:=shapes`
+
+## Launch file lookup
+
+There is a lookup process happening if the specified file is not an absolute
+path. It searches for a file with the given name in paths as follows:
+
+1. current directory
+1. all paths specified in environment variable `IGN_LAUNCH_CONFIG_PATH`
+1. a hardcoded install location (usually
+   `/usr/share/ignition/ignition-launchN/configs/`)
+
+The `IGN_LAUNCH_CONFIG_PATH` environment variable can contain either a single
+path or a path list (_new since 2.2.2_). Path list is a colon-separated (on
+UNIX) or semicolon-separated (on Windows) list of absolute paths.


### PR DESCRIPTION
# Bug Report

Fixes issue #92.

## Summary
Treat `IGN_LAUNCH_CONFIG_PATH` as a path list instead of just one path.

Depends on ign-common C bindings: https://github.com/ignitionrobotics/ign-common/pull/168 , because I felt reinventing the C++ wheel in Ruby is not really the way to go.

This is my first piece of code in Ruby, so give it a thorough check because I generally didn't know what I'm doing :) Most importantly, it'd be fine to find a way to use the Importer in such a way that importing the second library doesn't break the code loaded from the first one, but I couldn't wrap my head around it...

I was also thinking whether it's better to pass an absolute path to the ign-common library or just a filename, and decided just for the filename to ease having multiple ign-common versions side-by-side and choosing between them based on `LD_LIBRARY_PATH`. But passing the absolute path is possible if you'd think it's better for some reason.

I also didn't know how to add tests for this feature. However, there were none for the whole Ruby command file anyways...

I do the development on Dome, though it seemed to me this feature could go even in Citadel, so I pointed this PR to the Citadel version and maintain a 1-1 cherry-pick of it for Dome in https://github.com/peci1/ign-launch/tree/env-pathlist . That might speed up forward-porting of the feature, which I'm interested in :)

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] `codecheck` passed (See
  [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See
  [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review
[another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+archived%3Afalse+)
to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**