### PR TITLE
Image streaming over websocket

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ ign_find_package(TINYXML2 REQUIRED PRIVATE PRETTY tinyxml2)
 
 #--------------------------------------
 # Find ignition-common
-ign_find_package(ignition-common3 REQUIRED PRIVATE)
+ign_find_package(ignition-common3 REQUIRED PRIVATE COMPONENTS graphics)
 set(IGN_COMMON_MAJOR_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------

--- a/examples/websocket.ign
+++ b/examples/websocket.ign
@@ -12,7 +12,7 @@
 
     <!-- The maximum number of allowed connections. If this element is not
          defined or negative, then a limit is not enforced. -->
-    <max_connections>0</max_connections>
+    <max_connections>-1</max_connections>
 
     <!-- SSL configuration -->
     <!-- Specify the path to both the certificate and private key. -->

--- a/examples/websocket.ign
+++ b/examples/websocket.ign
@@ -7,8 +7,11 @@
           filename="ignition-launch-websocket-server">
     <publication_hz>30</publication_hz>
     <port>9002</port>
-    <authorization_key>auth_key</authorization_key>
-    <admin_authorization_key>admin_key</admin_authorization_key>
+
+    <!-- The following elements support authorization keys-->
+    <!-- <authorization_key>auth_key</authorization_key>
+         <admin_authorization_key>admin_key</admin_authorization_key>
+    -->
 
     <!-- The maximum number of allowed connections. If this element is not
          defined or negative, then a limit is not enforced. -->

--- a/plugins/websocket_server/CMakeLists.txt
+++ b/plugins/websocket_server/CMakeLists.txt
@@ -19,6 +19,7 @@ if (websockets_FOUND)
       ${websockets_LIBRARIES}
       ${PROJECT_LIBRARY_TARGET_NAME}
       ignition-common${IGN_COMMON_MAJOR_VER}::ignition-common${IGN_COMMON_MAJOR_VER}
+      ignition-common${IGN_COMMON_MAJOR_VER}::graphics
       ignition-msgs${IGN_MSGS_MAJOR_VER}::core
       ignition-plugin${IGN_PLUGIN_MAJOR_VER}::core
       ignition-transport${IGN_TRANSPORT_MAJOR_VER}::core

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -638,7 +638,6 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
         result.c_str(), result.size());
   }
 
-  // todo uncomment me
   if (!this->connections[_socketId]->authorized)
   {
     igndbg << "Unauthorized request received on socket[" << _socketId << "]\n";

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -260,7 +260,6 @@ int rootCallback(struct lws *_wsi,
       igndbg << "LWS_CALLBACK_HTTP\n";
       return httpCallback(_wsi, _reason, _user, _in, _len);
       break;
-
     // Publish outboud messages
     case LWS_CALLBACK_SERVER_WRITEABLE:
       {
@@ -638,11 +637,12 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
         result.c_str(), result.size());
   }
 
-  if (!this->connections[_socketId]->authorized)
-  {
-    igndbg << "Unauthorized request received on socket[" << _socketId << "]\n";
-    return;
-  }
+  // todo uncomment me
+//  if (!this->connections[_socketId]->authorized)
+//  {
+//    igndbg << "Unauthorized request received on socket[" << _socketId << "]\n";
+//    return;
+//  }
 
   // Handle the case where the client requests the message definitions.
   if (frameParts[0] == "protos")
@@ -761,6 +761,42 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
           this, std::placeholders::_1,
           std::placeholders::_2, std::placeholders::_3));
   }
+  else if (frameParts[0] == "image")
+  {
+    // Store the relation of socketId to subscribed topic.
+    this->topicConnections[frameParts[1]].insert(_socketId);
+    this->topicTimestamps[frameParts[1]] =
+      std::chrono::steady_clock::now() - this->publishPeriod;
+
+    std::vector<std::string> allTopics;
+    std::set<std::string> imageTopics;
+    this->node.TopicList(allTopics);
+    for (auto queryTopic: allTopics)
+    {
+      std::vector<transport::MessagePublisher> publishers;
+      this->node.TopicInfo(queryTopic, publishers);
+      for (auto pub: publishers)
+      {
+        if (pub.MsgTypeName() == "ignition.msgs.Image")
+        {
+          imageTopics.insert(queryTopic);
+          break;
+        }
+      }
+    }
+    std::string topic = frameParts[1];
+    if (!imageTopics.count(topic))
+    {
+      igndbg << "Could not find topic: " << topic  << " to stream"
+                << std::endl;
+      return;
+    }
+
+    igndbg << "Subscribe request to image topic[" << frameParts[1] << "]\n";
+    this->node.Subscribe(frameParts[1],
+        &WebsocketServer::OnWebsocketSubscribedImageMessage, this);
+  }
+
 }
 
 //////////////////////////////////////////////////
@@ -804,6 +840,50 @@ void WebsocketServer::OnWebsocketSubscribedMessage(
         {
           this->QueueMessage(this->connections[socketId].get(),
               msg.c_str(), msg.length());
+        }
+      }
+    }
+  }
+}
+
+//////////////////////////////////////////////////
+void WebsocketServer::OnWebsocketSubscribedImageMessage(
+    const ignition::msgs::Image &_msg,
+    const ignition::transport::MessageInfo &_info)
+{
+  std::map<std::string, std::set<int>>::const_iterator iter =
+    this->topicConnections.find(_info.Topic());
+
+  if (iter != this->topicConnections.end())
+  {
+    std::lock_guard<std::mutex> mainLock(this->subscriptionMutex);
+    std::chrono::time_point<std::chrono::steady_clock> systemTime =
+      std::chrono::steady_clock::now();
+
+    std::chrono::nanoseconds timeDelta =
+      systemTime - this->topicTimestamps[_info.Topic()];
+
+    if (timeDelta > this->publishPeriod)
+    {
+      // Store the last time this topic was published.
+      this->topicTimestamps[_info.Topic()] = systemTime;
+
+      // send raw png data
+      std::vector<unsigned char> buffer;
+      common::Image image;
+      image.SetFromData(
+          (unsigned char*) _msg.data().c_str(),
+          _msg.width(), _msg.height(), common::Image::RGB_INT8);
+      image.SavePNGToBuffer(buffer);
+      std::string img(reinterpret_cast<char *>(buffer.data()), buffer.size());
+
+      // Send the message
+      for (const int &socketId : iter->second)
+      {
+        if (this->connections.find(socketId) != this->connections.end())
+        {
+          this->QueueMessage(this->connections[socketId].get(),
+              img.c_str(), img.length());
         }
       }
     }

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <ignition/common/Console.hh>
+#include <ignition/common/Image.hh>
 #include <ignition/common/Util.hh>
 #include <ignition/msgs.hh>
 
@@ -638,11 +639,11 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
   }
 
   // todo uncomment me
-//  if (!this->connections[_socketId]->authorized)
-//  {
-//    igndbg << "Unauthorized request received on socket[" << _socketId << "]\n";
-//    return;
-//  }
+  if (!this->connections[_socketId]->authorized)
+  {
+    igndbg << "Unauthorized request received on socket[" << _socketId << "]\n";
+    return;
+  }
 
   // Handle the case where the client requests the message definitions.
   if (frameParts[0] == "protos")

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -150,6 +150,9 @@ namespace ignition
                    const size_t _size,
                    const ignition::transport::MessageInfo &_info);
 
+      /// \brief Callback when an image is received on a topic
+      /// \param[in] _msg Image msg
+      /// \param[in] _info ign transport message info
       private: void OnWebsocketSubscribedImageMessage(
           const ignition::msgs::Image &_msg,
           const ignition::transport::MessageInfo &_info);

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -150,6 +150,10 @@ namespace ignition
                    const size_t _size,
                    const ignition::transport::MessageInfo &_info);
 
+      private: void OnWebsocketSubscribedImageMessage(
+          const ignition::msgs::Image &_msg,
+          const ignition::transport::MessageInfo &_info);
+
       /// \brief Callback that is triggered when a new connection is
       /// established.
       /// \param[in] _socketId ID of the socket.


### PR DESCRIPTION
depends on https://github.com/ignitionrobotics/ign-common/pull/139

# 🎉 New feature

## Summary

Adds support for streaming images from an ign topic.

Added keyword `image` for requesting data from an image topic. The websocket server plugin will subscribe to the topic in the request and republish the image data over to the client.

A better solution maybe to use a proper streaming server like HTTP Live Streaming (HLS) protocol in the future.

## Test it

Launch ign gazebo camera sensor example world:

```
ign gazebo -v 4 -r src/ign-gazebo/examples/worlds/camera_sensor.sdf
```

Launch ign websocket server example launch file

```
ign launch -v 4 src/ign-launch/examples/websocket.ign
```

See the image stream using this demo [image_stream_websocket_client.html file](https://gist.github.com/iche033/9f2ca7af834af70f6e3288255f484aa4)

![ign_image_streamer](https://user-images.githubusercontent.com/4000684/108583868-82148600-72f1-11eb-8eac-bf1dde8fafb1.png)

Note the red and blue channels are reversed in the image stream, which may be fixed by https://github.com/ignitionrobotics/ign-common/pull/162

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**


