### PR TITLE
Support getting topic names and message types

### DIFF
--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -85,7 +85,9 @@ namespace ignition
     ///     1. "sub": Subscribe to the topic in the `topic_name` component,
     ///     2. "pub": Publish a message from the Ignition Transport topic in
     ///               the `topic_name` component,
-    ///     3. "topics": Get the list of available topics, and
+    ///     3. "topics": Get the list of available topics,
+    ///     3. "topics-types": Get the list of available topics and their
+    ///                        message types, and
     ///     4. "protos": Get a string containing all the protobuf
     ///                  definitions.
     ///


### PR DESCRIPTION
# 🎉 New feature

## Summary

Support returning a list of topics and their message types using the websocket server.

## Test it

Run the websocket server, and request "topics-types". You can test using https://gitlab.com/ignitionrobotics/web/app/-/merge_requests/111

## Checklist
- [X] Signed all commits for DCO
- [ ] ~~Added tests~~
- [ ] ~~Added example and/or tutorial~~
- [X] Updated documentation (as needed)
- [ ] ~~Updated migration guide (as needed)~~
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**