### PR TITLE
Support particle_emitters in the websocket server

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -748,6 +748,37 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
     this->QueueMessage(this->connections[_socketId].get(),
         data.c_str(), data.length());
   }
+  /// \todo(nkoeng) Deprecate this in Ignition Fortress, and instruct users
+  /// to rely on the "scene" message.
+  else if (frameParts[0] == "particle_emitters")
+  {
+    igndbg << "Particle emitter request recieved for world["
+      << frameParts[1] << "]\n";
+    ignition::msgs::Empty req;
+    req.set_unused(true);
+
+    ignition::msgs::ParticleEmitter_V rep;
+    bool result;
+    unsigned int timeout = 2000;
+
+    std::string serviceName = std::string("/world/") + frameParts[1] +
+      "/particle_emitters";
+
+    bool executed = this->node.Request(serviceName, req, timeout, rep, result);
+    if (!executed || !result)
+    {
+      ignerr << "Failed to get the particle emitter information for "
+        << frameParts[1] << " world.\n";
+    }
+
+    std::string data = BUILD_MSG(this->operations[PUBLISH], frameParts[0],
+        std::string("ignition.msgs.ParticleEmitter_V"),
+        rep.SerializeAsString());
+
+    // Queue the message for delivery.
+    this->QueueMessage(this->connections[_socketId].get(),
+        data.c_str(), data.length());
+  }
   else if (frameParts[0] == "sub")
   {
     // Store the relation of socketId to subscribed topic.

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -752,7 +752,7 @@ void WebsocketServer::OnMessage(int _socketId, const std::string &_msg)
   /// to rely on the "scene" message.
   else if (frameParts[0] == "particle_emitters")
   {
-    igndbg << "Particle emitter request recieved for world["
+    igndbg << "Particle emitter request received for world["
       << frameParts[1] << "]\n";
     ignition::msgs::Empty req;
     req.set_unused(true);

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -85,9 +85,10 @@ namespace ignition
     ///     1. "sub": Subscribe to the topic in the `topic_name` component,
     ///     2. "pub": Publish a message from the Ignition Transport topic in
     ///               the `topic_name` component,
-    ///     3. "topics": Get the list of available topics, and
+    ///     3. "topics": Get the list of available topics,
     ///     4. "protos": Get a string containing all the protobuf
-    ///                  definitions.
+    ///                  definitions, and
+    ///     5. "particle_emitters": Get the list of particle emitters.
     ///
     /// The `topic_name` component is mandatory for the "sub" and "pub"
     /// operations. If present, it must be the name of an Ignition Transport


### PR DESCRIPTION
# 🎉 New feature

## Summary

Adds a call to service provided by [ParticleEmitter2](https://github.com/ignitionrobotics/ign-gazebo/pull/730) in the websocket plugin. This call supports returning the list of particle emitters to a client, such as gz3d.
 
This functionality will be deprecated in Ignition Fortress. Users will be able to rely on the Scene message from Ignition Fortress on.

This is part of a series of pull requests designed to support particle emitter in gz3d.
See also:
  * ~~https://github.com/ignitionrobotics/ign-msgs/pull/149~~
  * https://github.com/ignitionrobotics/ign-gazebo/pull/730
  * ~~https://github.com/osrf/sdformat/pull/528~~

## Test it

Run the web application using both:
1. https://gitlab.com/ignitionrobotics/web/app/-/merge_requests/113
2. https://gitlab.com/ignitionrobotics/web/gz3d/-/merge_requests/44

Using `websocket.ign` and `fog.sdf` from https://gist.github.com/nkoenig/cd3f5cbf69be97f04190e3cfaa155423:

1. `ign launch -v 4 websocket.ign`
2. To to the `/visualize` route on the web app, and click connect.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**