### PR TITLE
Bump main to 5.0.0~pre1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.5.1 FATAL_ERROR)
 #============================================================================
 # Initialize the project
 #============================================================================
-project(ignition-launch4 VERSION 4.0.0)
+project(ignition-launch5 VERSION 5.0.0)
 
 #============================================================================
 # Find ignition-cmake

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Ignition Launch 5.x
+
+### Ignition Launch 5.X.X (20XX-XX-XX)
+
+### Ignition Launch 5.0.0 (20XX-XX-XX)
+
 ## Ignition Launch 4.x
 
 ### Ignition Launch 4.X.X (20XX-XX-XX)


### PR DESCRIPTION
Branch `ign-launch4` has been created for the Edifice release and 4.0.0 released from that.

The `main` branch now corresponds to version 5.0.0~pre1, and nightlies will soon be created from this branch.

https://github.com/ignition-tooling/release-tools/issues/421