### PR TITLE
Convert depth and thermal image data to RGB before sending over websockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,8 @@ ign_find_package(TINYXML2 REQUIRED PRIVATE PRETTY tinyxml2)
 
 #--------------------------------------
 # Find ignition-common
-ign_find_package(ignition-common3 REQUIRED PRIVATE COMPONENTS graphics)
+ign_find_package(ignition-common3 REQUIRED VERSION 3.13
+  PRIVATE COMPONENTS graphics)
 set(IGN_COMMON_MAJOR_VER ${ignition-common3_VERSION_MAJOR})
 
 #--------------------------------------


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@osrfoundation.org>

# 🎉 New feature

## Summary

Depends on https://github.com/ignitionrobotics/ign-common/pull/205

Depth (`float`) and thermal camera image data (`uint8_t` and `uint16_t`) are now converted to RGB images before sending over websockets to the client side. This should be transparent to the client and no changes should be needed to display these images.


## Test it

Test with [sensors_demo.sdf](https://github.com/ignitionrobotics/ign-gazebo/blob/ign-gazebo5/examples/worlds/sensors_demo.sdf) world by using this launch file:
```
<?xml version='1.0'?>
<ignition version='1.0'>
  <executable name='gazebo-server'>
    <command>ign gazebo -v 4 -r sensors_demo.sdf</command>
  </executable>

  <plugin name="ignition::launch::WebsocketServer"
          filename="ignition-launch-websocket-server">
    <port>9002</port>
  </plugin>
</ignition>
```

1. Launch webapp
2. Go to System Admin page (need permission) -> Websockets
3. Connect to the local server
4. Check the camera topics to see the images rendered below the gz3d window

![image_visualization_webapp](https://user-images.githubusercontent.com/4000684/115930157-d812c080-a43d-11eb-9f1b-80aaf9892dea.png)


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**
