### PR TITLE
Extend websocket server to support message limits and throttling

### DIFF
--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -175,7 +175,6 @@ namespace ignition
 
       public: void OnRequestMessage(int _socketId, const std::string &_msg);
 
-
       /// \brief Check and update subscription count for a message type. If
       /// a client has more subscriptions to a topic of a specified type than
       /// the subscription limit, this will block subscription. On the other
@@ -184,6 +183,8 @@ namespace ignition
       /// \param[in] _socketId Connection socket id
       /// \param[in] _subscribe True for subscribe operation, false for
       /// unsubscribe operation
+      /// \return True if the subscription count is incremented or decremented,
+      /// and false to indicate the subcription limit has reached.
       public: bool UpdateMsgTypeSubscriptionCount(const std::string &_topic,
           int _socketId, bool _subscribe);
 

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -190,6 +190,21 @@ namespace ignition
         public: std::mutex mutex;
 
         public: bool authorized{false};
+
+        /// \brief A map of topic name to outbound publish rate
+        /// A value of 0 means unthrottled
+        public: std::map<std::string, std::chrono::nanoseconds>
+            topicPublishPeriods;
+
+        /// \brief A map of topic name to timestamp of last published message
+        /// for this connection
+        public: std::map<std::string,
+            std::chrono::time_point<std::chrono::steady_clock>> topicTimestamps;
+
+        /// \brief The number of subscriptions of a msg type this connection
+        /// has. The key is the msg type, e.g. ignition.msgs.Image, and the
+        /// value is the subscription count
+        public: std::map<std::string, int> msgTypeSubscriptionCount;
       };
 
       private: void QueueMessage(Connection *_connection,
@@ -208,6 +223,11 @@ namespace ignition
       /// The key is the topic name, and the value is the set of websocket
       /// connections that have subscribed to the topic.
       public: std::map<std::string, std::set<int>> topicConnections;
+
+      /// \brief The limit placed on the number of subscriptions per msg type
+      /// for each connection. The key is the msg type, e.g.
+      /// ignition.msgs.Image, and the value is the subscription limit
+      public: std::map<std::string, int> msgTypeSubscriptionLimit;
 
       /// \brief Run loop mutex.
       public: std::mutex runMutex;
@@ -229,6 +249,10 @@ namespace ignition
       private: std::map<std::string,
                std::chrono::time_point<std::chrono::steady_clock>>
                  topicTimestamps;
+
+      /// \brief The message queue size per connection. A negative number
+      /// indicates no limit.
+      public: int queueSizePerConnection{-1};
 
       /// \brief The set of valid operations. This enum must align with the
       /// `operations` member variable.

--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -175,6 +175,18 @@ namespace ignition
 
       public: void OnRequestMessage(int _socketId, const std::string &_msg);
 
+
+      /// \brief Check and update subscription count for a message type. If
+      /// a client has more subscriptions to a topic of a specified type than
+      /// the subscription limit, this will block subscription. On the other
+      /// hand, for an unsubscription operation, the count is decremented.
+      /// \param[in] _topic Topic to subscribe to or unsubscribe from
+      /// \param[in] _socketId Connection socket id
+      /// \param[in] _subscribe True for subscribe operation, false for
+      /// unsubscribe operation
+      public: bool UpdateMsgTypeSubscriptionCount(const std::string &_topic,
+          int _socketId, bool _subscribe);
+
       private: ignition::transport::Node node;
 
       private: bool run = true;


### PR DESCRIPTION
## Summary

Added 3 new features:

* setting max msg queue size
    * Msg published to websocket clients can now have a msg queue size limit to prevent the queue from infinitely growing. You can now set this by specifying:
    ```
      <queue_size_per_connection>10</queue_size_per_connection>
    ```
    * see https://github.com/osrf/subt/pull/950
    *  To test, run web app, and navigate to the websocket visualizer page. Connect to a point cloud topic, then use browser debugger to pause the page and verify that memory usage does not keep growing.

* throttling publish rate for topics
   * Added a keyword `throttle` that can be used by clients to limit the publish rate of a specific topic. This is initiated by the websocket client and it affects all clients who are subscribed to that topic.
   * see related [pull request](https://gitlab.com/ignitionrobotics/web/app/-/merge_requests/122) in web app

* limiting number of subscriptions per msg type
    * some msg types have large message size. So this configuration allows users to limit the number of subscriptions that each connection can open for a particular msg type, e.g. the following limits each client to subscribe to only 1 point cloud topic

    ```
    <subscription_limit_per_connection>
      <subscription>
        <msg_type>ignition.msgs.PointCloudPacked</msg_type>
        <limit>1</limit>
      </subscription>
    </subscription_limit_per_connection>
    ```
    * see https://github.com/osrf/subt/pull/950
    * To test, run web app, go to cloudsim's websocket visualizer, and try to connect to multiple point cloud topics. With the above configuration, only one can be visualized.




## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**

