### PR TITLE
Max connections error

### DIFF
--- a/plugins/websocket_server/WebsocketServer.hh
+++ b/plugins/websocket_server/WebsocketServer.hh
@@ -4,7 +4,7 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+*
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
@@ -51,6 +51,13 @@ namespace ignition
     /// this is set, then a connection must provide the matching key using an
     /// "auth" call on the websocket. If the <authorization_key> is set, then
     /// the connection can provide that key.
+    ///
+    /// * <max_connections> : An integer that specifies the maximum number
+    /// of active websocket connections. A value less than zero indicates an
+    /// unlimited number, this is the default. A websocket client error
+    /// code of 1008 along with a reason set to "max_connections" will be
+    /// returned if a new connection is rejected due to the max connection
+    /// threshold.
     ///
     /// * <ssl> : Element that contains SSL configuration. For testing
     ///           purposes you can create self-signed SSL certificates. Run


### PR DESCRIPTION
# 🎉 New feature

## Summary

Return a new error code and message when a websocket connection hits the `max_connections` threshold.

## Test it
I tested this using subt:
```
ign launch -v 4 cloudsim_sim.ign worldName:=simple_cave_01 circuit:=cave websocketMaxConnections:=0
```

The use the web-app visualizer to attempt a connection.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge**