### PR TITLE
Remove Bionic from future releases (Garden+)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,6 @@ name: Ubuntu CI
 on: [push, pull_request]
 
 jobs:
-  bionic-ci:
-    runs-on: ubuntu-latest
-    name: Ubuntu Bionic CI
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Compile and test
-        id: ci
-        uses: ignition-tooling/action-ignition-ci@bionic
-        with:
-          codecov-enabled: true
   focal-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Focal CI
@@ -23,3 +12,5 @@ jobs:
       - name: Compile and test
         id: ci
         uses: ignition-tooling/action-ignition-ci@focal
+        with:
+          codecov-enabled: true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 Build | Status
 -- | --
 Test coverage | [![codecov](https://codecov.io/gh/ignitionrobotics/ign-launch/branch/ign-launch5/graph/badge.svg)](https://codecov.io/gh/ignitionrobotics/ign-launch)
-Ubuntu Bionic | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_launch-ci-ign-launch5-bionic-amd64)](https://build.osrfoundation.org/job/ignition_launch-ci-ign-launch5-bionic-amd64)
+Ubuntu Focal | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_launch-ci-ign-launch5-focal-amd64)](https://build.osrfoundation.org/job/ignition_launch-ci-ign-launch5-focal-amd64)
 Homebrew      | [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ignition_launch-ci-ign-launch5-homebrew-amd64)](https://build.osrfoundation.org/job/ignition_launch-ci-ign-launch5-homebrew-amd64)
 Windows       | [![Build Status](https://build.osrfoundation.org/job/ign_launch-ign-5-win/badge/icon)](https://build.osrfoundation.org/job/ign_launch-ign-5-win/)
 

--- a/tutorials/install.md
+++ b/tutorials/install.md
@@ -19,7 +19,7 @@ We recommend following the [Binary Install](#binary-install) instructions to get
 
 The [Source Install](#source-install) instructions should be used if you need the very latest software improvements, you need to modify the code, or you plan to make a contribution.
 
-## Ubuntu 18.04 or above
+## Ubuntu 20.04 or above
 
 On Ubuntu systems, `apt` can be used to install `ignition-launch`:
 
@@ -49,14 +49,14 @@ which version you need.
 # Source Install
 
 
-## Ubuntu 18.04 or above
+## Ubuntu 20.04 or above
 
 Source installation can be performed in UNIX systems by first installing the
 necessary prerequisites followed by building from source.
 
 ### Prerequisites
 
-**[Ubuntu Bionic](http://releases.ubuntu.com/18.04/)**
+**[Ubuntu Focal](http://releases.ubuntu.com/20.04/)** or higher
 
 1. Install third-party libraries:
 


### PR DESCRIPTION
* See https://github.com/ignition-tooling/release-tools/issues/597

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

`ign-launch6` will be on Garden.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

No Bionic builds should be triggered.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
