### PR TITLE
Use exec instead of popen to run ign-launch binary

### DIFF
--- a/src/cmd/cmdlaunch.rb.in
+++ b/src/cmd/cmdlaunch.rb.in
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'open3'
-
 # Constants.
 LIBRARY_VERSION = '@PROJECT_VERSION_FULL@'
 COMMANDS = {
@@ -50,16 +48,6 @@ class Cmd
     end
 
     # Drop command from list of arguments
-    Open3.popen2e(exe_name, *args[1..-1]) do |_in, out_err, wait_thr|
-      begin
-        out_err.each do |line|
-          print line
-        end
-        exit(wait_thr.value.exitstatus)
-      rescue Interrupt => e
-        print e.message
-        exit(-1)
-      end
-    end
+    exec(exe_name, *args[1..-1])
   end
 end


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #149 

## Summary
Currently, the ruby processes creates a new process to run the `ign-launch` binary. For some reason, signals sent to the ruby processes don't propagate to the child process. In addition to the issue described in #149, sending a `SIGINT` signal (or even `SIGKILL`)  directly via `kill` to the parent process doesn't terminate the launched process.

For example, launch the following:

`sleep.ign`
```xml
<?xml version='1.0'?>
<ignition version='1.0'>
  <executable name='sleep_ign'>
    <command>sleep 100</command>
  </executable>
</ignition>
```

Launch with: `ign launch sleep.ign`

The process list shows there are two processes associated with the launch
```
❯ ps x --forest  | grep ign
1423316 pts/24   Sl+    0:00  |   |   \_ ign launch sleep.ign
1423346 pts/24   Sl+    0:00  |   |       \_ /home/addisu/ws/fortress/install/lib/ignition/launch5/ign-launch sleep.ign
```
Killing the top/parent process does not terminate the child
```
❯ kill -SIGINT 1423316
❯ ps x --forest  | grep ign
1423346 pts/24   Sl     0:00  \_ /home/addisu/ws/fortress/install/lib/ignition/launch5/ign-launch sleep.ign
```

https://www.vidarholen.net/contents/blog/?p=34 explains the problem (which I learned about from https://github.com/ros2/launch/issues/484).

The solution I propose is to replace the ruby process with the `ign-launch` process using `exec`. Here's the process list with the new approach.

```
❯ ps x --forest  | grep ign
1431877 pts/24   Sl+    0:00  |   |   \_ /home/addisu/ws/fortress/install/lib/ignition/launch5/ign-launch sleep.ign

```

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
