### PR TITLE
Fix compatibility with protobuf v30 (cpp 6.30.0)

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -1055,7 +1055,7 @@ void WebsocketServer::OnRequest(int _socketId,
     gz::msgs::StringMsg msg;
     msg.set_data("service_not_found");
     std::string data = BUILD_MSG(this->operations[REQUEST], service,
-        msg.GetTypeName(), msg.SerializeAsString());
+        std::string(msg.GetTypeName()), msg.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),
@@ -1094,7 +1094,7 @@ void WebsocketServer::OnAsset(int _socketId,
     gz::msgs::StringMsg msg;
     msg.set_data("asset_uri_missing");
     std::string data = BUILD_MSG(this->operations[ASSET], "",
-        msg.GetTypeName(), msg.SerializeAsString());
+        std::string(msg.GetTypeName()), msg.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),
@@ -1140,7 +1140,7 @@ void WebsocketServer::OnAsset(int _socketId,
 
     // Construct the response message
     std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-        bytes.GetTypeName(), bytes.SerializeAsString());
+        std::string(bytes.GetTypeName()), bytes.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),
@@ -1151,7 +1151,7 @@ void WebsocketServer::OnAsset(int _socketId,
     gz::msgs::StringMsg msg;
     msg.set_data("asset_not_found");
     std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-        msg.GetTypeName(), msg.SerializeAsString());
+        std::string(msg.GetTypeName()), msg.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),


### PR DESCRIPTION
# 🦟 Bug fix

Permit to compilation with protobuf version higher then 30.

Similar to:
* https://github.com/gazebosim/gz-msgs/pull/499
* https://github.com/gazebosim/gz-transport/pull/615
* https://github.com/gazebosim/gz-gui/pull/677

## Summary

As protobuf 30 changed some return types to be `std::string_view`, wrap some functions with `std::string` to ensure that eventually ` std::string` is created.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

