### PR TITLE
Update launch tutorial

### DIFF
--- a/examples/factory.gzlaunch
+++ b/examples/factory.gzlaunch
@@ -21,7 +21,7 @@
           </plugin>
 
           <!-- Publish robot joint state information -->
-          <plugin filename="gz-sim-state-publisher-system"
+          <plugin filename="gz-sim-joint-state-publisher-system"
                   name="gz::sim::systems::JointStatePublisher"></plugin>
         </include>
       </sdf>

--- a/plugins/sim_factory/SimFactory.cc
+++ b/plugins/sim_factory/SimFactory.cc
@@ -211,5 +211,5 @@ bool SimFactory::Load(const tinyxml2::XMLElement *_elem)
 
 
 
-  return false;
+  return true;
 }

--- a/plugins/sim_factory/SimFactory.cc
+++ b/plugins/sim_factory/SimFactory.cc
@@ -150,6 +150,7 @@ bool SimFactory::Load(const tinyxml2::XMLElement *_elem)
   // one "spawn" request is embedded in the plugin.
   this->ProcessSpawn(_elem);
 
+  bool loadResult = true;
   for (const auto &msg : this->worldFactoryMsgs)
   {
     uint32_t timeout = 2000;
@@ -206,10 +207,9 @@ bool SimFactory::Load(const tinyxml2::XMLElement *_elem)
       {
         gzerr << "Factory service call timed out.\n";
       }
+      loadResult = false;
     }
   }
 
-
-
-  return true;
+  return loadResult;
 }

--- a/tutorials/tutorial.md
+++ b/tutorials/tutorial.md
@@ -73,9 +73,9 @@ gz launch sim_plugins.gzlaunch worldName:=shapes
 ```
 
 > Note: This example requires that you have a joystick plugged in.
-   If you don't have one, you will see some error messages complaining that
-   it can not find any joystick / input devices and the plugin will fail
-   to load. This is expected.
+> If you don't have one, you will see some error messages complaining that
+> it can not find any joystick / input devices and the plugin will fail
+> to load. This is expected.
 
 ## Launch file lookup
 

--- a/tutorials/tutorial.md
+++ b/tutorials/tutorial.md
@@ -36,7 +36,19 @@ Take a look at the [sim.gzlaunch](https://github.com/gazebosim/gz-launch/blob/gz
 
 ## Spawn a robot into simulation with plugins
 
-Now take a look at the [factory.gzlaunch](https://github.com/gazebosim/gz-launch/blob/gz-launch9/examples/factory.gzlaunch) launch file. We defined a `SimFactory` plugin under which we included an `X2 UGV` robot and added the `DiffDrive` plugin to control the robot. We also added the `StatePublisher` plugin which publishes the robot state information.
+Now take a look at the [factory.gzlaunch](https://github.com/gazebosim/gz-launch/blob/gz-launch9/examples/factory.gzlaunch) launch file. We defined a `SimFactory` plugin under which we included an `X2 UGV` robot and added the `DiffDrive` plugin to control the robot. We also added the `JointStatePublisher` plugin which publishes the robot state information.
+
+First launch Gazebo in an empty world
+
+```
+gz sim -v 4 empty.sdf
+```
+
+In another terminal, spawn the robot into simulation using gz-launch
+
+```
+gz launch -v 4 factory.gzlaunch
+```
 
 ## Launch simulation with plugins in separate processes
 
@@ -48,13 +60,22 @@ plugin also launches into a separate process and transforms a `joystick` message
 
 The script can take a world as an argument. To run this script.
 
-`gz launch sim_plugins.gzlaunch [worldName:=<worldName>]`
+```
+gz launch sim_plugins.gzlaunch [worldName:=<worldName>]
+```
 
 The [worldName] command line argument is optional. If left blank, or not specified, then "diff_drive" is used for the world name.
 
 Example to load `the shapes.sdf`:
 
-`gz launch sim_plugins.gzlaunch worldName:=shapes`
+```
+gz launch sim_plugins.gzlaunch worldName:=shapes
+```
+
+> Note: This example requires that you have a joystick plugged in.
+   If you don't have one, you will see some error messages complaining that
+   it can not find any joystick / input devices and the plugin will fail
+   to load. This is expected.
 
 ## Launch file lookup
 

--- a/tutorials/tutorial.md
+++ b/tutorials/tutorial.md
@@ -40,13 +40,13 @@ Now take a look at the [factory.gzlaunch](https://github.com/gazebosim/gz-launch
 
 First launch Gazebo in an empty world
 
-```
+```bash
 gz sim -v 4 empty.sdf
 ```
 
 In another terminal, spawn the robot into simulation using gz-launch
 
-```
+```bash
 gz launch -v 4 factory.gzlaunch
 ```
 
@@ -60,7 +60,7 @@ plugin also launches into a separate process and transforms a `joystick` message
 
 The script can take a world as an argument. To run this script.
 
-```
+```bash
 gz launch sim_plugins.gzlaunch [worldName:=<worldName>]
 ```
 
@@ -68,7 +68,7 @@ The [worldName] command line argument is optional. If left blank, or not specifi
 
 Example to load `the shapes.sdf`:
 
-```
+```bash
 gz launch sim_plugins.gzlaunch worldName:=shapes
 ```
 


### PR DESCRIPTION


# 🦟 Bug fix

Related issue: https://github.com/gazebosim/gazebo_test_cases/issues/1971#issuecomment-3237925315

## Summary

* Updated instructions in the tutorial
* Fixed joint state publisher system name in `factory.gzlaunch`
* Updated simFactory plugin to return `true` after successfully loading the plugin 


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

