### PR TITLE
Replaces the C-style variable-length array (VLA) with std::vector

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -16,6 +16,7 @@
 */
 
 #include <algorithm>
+#include <vector>
 
 #include <gz/msgs/bytes.pb.h>
 #include <gz/msgs/empty.pb.h>
@@ -174,9 +175,9 @@ int httpCallback(struct lws *_wsi,
 
         // Prepare the output
         size_t buflen = strlen(format) + (conns.size() - 1);
-        unsigned char buf[buflen + LWS_PRE];
+        std::vector<unsigned char> buf(buflen + LWS_PRE);
         int n;
-        n = snprintf(reinterpret_cast<char *>(buf), buflen, format,
+        n = snprintf(reinterpret_cast<char *>(buf.data()), buflen, format,
             conns.c_str());
         // Check that no characters were discarded
         if (n - int(buflen) > 0)
@@ -192,8 +193,8 @@ int httpCallback(struct lws *_wsi,
 
         // Write response body
         lws_write_http(_wsi,
-                       reinterpret_cast<unsigned char *>(buf),
-                       strlen(reinterpret_cast<const char *>(buf)));
+                       buf.data(),
+                       strlen(reinterpret_cast<const char *>(buf.data())));
         break;
       }
       // Return a 404 if no route was matched


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #313 

## Summary

The fix replaces the C-style variable-length array with std::vector<unsigned char>, which is standard C++.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Opus 4.6

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.