### PR TITLE
Fix compatibility with protobuf v30 (cpp 6.30.0)

### DIFF
--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -32,7 +32,7 @@ using namespace ignition::launch;
 /// \param[in] _topic The topic name string.
 /// \param[in] _type The message type string.
 /// \return A string that is the frame header.
-#define BUILD_HEADER(_op, _topic, _type) ((_op)+","+(_topic)+","+(_type)+",")
+#define BUILD_HEADER(_op, _topic, _type) ((_op)+","+(_topic)+","+(std::string(_type))+",")
 
 /// \brief Construction a complete websocket frame.
 /// \param[in] _op The operation string.


### PR DESCRIPTION
# 🦟 Bug fix

follows as #303 

## Summary

A missed fix for compatibility with protobuf v30

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)



**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
