### PR TITLE
Porting the security fix from gazebosim/gz-sim#3643

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,11 @@ gz_find_package (Qt5
 gz_find_package(gz-sim9 REQUIRED PRIVATE COMPONENTS gui)
 set(GZ_SIM_VER ${gz-sim9_VERSION_MAJOR})
 
+#--------------------------------------
+# Find gz-fuel_tools
+gz_find_package(gz-fuel_tools10 REQUIRED PRIVATE)
+set(GZ_FUEL_TOOLS_VER ${gz-fuel_tools10_VERSION_MAJOR})
+
 gz_pkg_check_modules(websockets libwebsockets)
 if (NOT websockets_FOUND)
   gz_build_warning("Unable to find libwebsockets. The websocket_server plugin will not be built.")

--- a/plugins/websocket_server/CMakeLists.txt
+++ b/plugins/websocket_server/CMakeLists.txt
@@ -23,6 +23,8 @@ if (websockets_FOUND)
       gz-msgs${GZ_MSGS_VER}::core
       gz-plugin${GZ_PLUGIN_VER}::core
       gz-transport${GZ_TRANSPORT_VER}::core
+      gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
+      gz-fuel_tools${GZ_FUEL_TOOLS_VER}::gz-fuel_tools${GZ_FUEL_TOOLS_VER}
   )
 
   install (TARGETS ${plugin} DESTINATION ${GZ_LAUNCH_PLUGIN_RELATIVE_INSTALL_PATH})

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -16,6 +16,9 @@
 */
 
 #include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <system_error>
 
 #include <gz/msgs/bytes.pb.h>
 #include <gz/msgs/empty.pb.h>
@@ -28,9 +31,13 @@
 #include <gz/msgs/stringmsg_v.pb.h>
 
 #include <gz/common/Console.hh>
+#include <gz/common/Filesystem.hh>
 #include <gz/common/Image.hh>
+#include <gz/common/SystemPaths.hh>
 #include <gz/common/Util.hh>
 #include <gz/msgs/Factory.hh>
+#include <gz/sim/Util.hh>
+#include <gz/fuel_tools/ClientConfig.hh>
 #include <gz/transport/Publisher.hh>
 
 #include "MessageDefinitions.hh"
@@ -1094,7 +1101,7 @@ void WebsocketServer::OnAsset(int _socketId,
     gz::msgs::StringMsg msg;
     msg.set_data("asset_uri_missing");
     std::string data = BUILD_MSG(this->operations[ASSET], "",
-        std::string(msg.GetTypeName()), msg.SerializeAsString());
+        msg.GetTypeName(), msg.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),
@@ -1106,6 +1113,37 @@ void WebsocketServer::OnAsset(int _socketId,
   std::string assetUri = _frameParts[1];
 
   std::string resolvedPath;
+
+  // Queue an ASSET error response (e.g. "asset_not_found") for this request.
+  auto sendAssetError = [this, _socketId, &assetUri](const std::string &_code)
+  {
+    gz::msgs::StringMsg msg;
+    msg.set_data(_code);
+    std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
+        msg.GetTypeName(), msg.SerializeAsString());
+
+    this->QueueMessage(this->connections[_socketId].get(),
+        data.c_str(), data.length());
+  };
+
+  // Helper function to extract paths from an environment
+  auto extractPathsFromEnv = [](const std::string &_envVar)
+    -> std::vector<std::string>
+  {
+    std::vector<std::string> paths;
+    const char *envVal = std::getenv(_envVar.c_str());
+    if (envVal)
+    {
+      std::string envStr(envVal);
+      std::stringstream ss(envStr);
+      std::string path;
+      while (std::getline(ss, path, common::SystemPaths::Delimiter()))
+      {
+        paths.push_back(path);
+      }
+    }
+    return paths;
+  };
 
   // Short circuit the case where the assetURI is already a valid path.
   if (common::exists(assetUri))
@@ -1126,37 +1164,139 @@ void WebsocketServer::OnAsset(int _socketId,
       resolvedPath = rep.data();
   }
 
-  if (!resolvedPath.empty())
+  if (resolvedPath.empty())
   {
-    // Read the file
-    std::ifstream infile(resolvedPath, std::ios_base::binary);
-    std::string fileBuffer = std::string(
-        std::istreambuf_iterator<char>(infile),
-        std::istreambuf_iterator<char>());
-
-    // Store the file in a protobuf message
-    gz::msgs::Bytes bytes;
-    bytes.set_data(fileBuffer);
-
-    // Construct the response message
-    std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-        std::string(bytes.GetTypeName()), bytes.SerializeAsString());
-
-    // Queue the message for delivery.
-    this->QueueMessage(this->connections[_socketId].get(),
-        data.c_str(), data.length());
+    sendAssetError("asset_not_found");
+    gzwarn << "Resolved Path is empty" << "\n";
+    return;
   }
-  else
+
+  // This logic protects against arbitrary read access.
+  bool allowed = false;
+  std::string canonicalResolved;
+  try
   {
-    gz::msgs::StringMsg msg;
-    msg.set_data("asset_not_found");
-    std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
-        std::string(msg.GetTypeName()), msg.SerializeAsString());
+    std::error_code ec;
+    canonicalResolved =
+        std::filesystem::weakly_canonical(resolvedPath, ec).string();
 
-    // Queue the message for delivery.
-    this->QueueMessage(this->connections[_socketId].get(),
-        data.c_str(), data.length());
+    if (!ec)
+    {
+      std::vector<std::string> allowedPaths = sim::resourcePaths();
+      fuel_tools::ClientConfig fuelConfig;
+      std::string fuelCachePath = fuelConfig.CacheLocation();
+
+      auto extraSdfPaths = extractPathsFromEnv(sim::kSdfPathEnv);
+      allowedPaths.reserve(allowedPaths.size() + extraSdfPaths.size());
+      allowedPaths.insert(allowedPaths.end(), extraSdfPaths.begin(),
+          extraSdfPaths.end());
+
+      common::SystemPaths systemPaths;
+      auto extraFilePaths = systemPaths.FilePaths();
+      allowedPaths.reserve(allowedPaths.size() + extraFilePaths.size());
+      allowedPaths.insert(allowedPaths.end(), extraFilePaths.begin(),
+          extraFilePaths.end());
+
+      if (!fuelCachePath.empty())
+      {
+        allowedPaths.push_back(fuelCachePath);
+      }
+
+      for (const std::string &resPath : allowedPaths)
+      {
+        std::error_code pathEc;
+        std::string canonicalRes = "";
+        try
+        {
+          canonicalRes =
+              std::filesystem::weakly_canonical(resPath, pathEc).string();
+          if (pathEc || canonicalRes.empty())
+          {
+            gzwarn << "Failed to resolve canonical path for resource path["
+                  << resPath << "]: " << pathEc.message() << "\n";
+            continue;
+          }
+        }
+        catch (std::exception &e)
+        {
+          gzwarn << "Failed to resolve canonical path for resource path["
+                << resPath << "]: " << e.what() << "\n";
+          continue;
+        }
+        std::string canonicalResNoSep = canonicalRes;
+
+        // Ensure trailing separator
+        if (canonicalRes.back() != '/' && canonicalRes.back() != '\\')
+        {
+          canonicalRes = common::separator(canonicalRes);
+        }
+
+        if (canonicalResolved == canonicalResNoSep ||
+            canonicalResolved.rfind(canonicalRes, 0) == 0)
+        {
+          allowed = true;
+          break;
+        }
+      }
+    }
+    else
+    {
+      gzerr << "Failed to resolve canonical path for [" << resolvedPath
+            << "]: " << ec.message() << "\n";
+    }
   }
+  catch (const std::exception &_e)
+  {
+    gzerr << "Exception thrown while resolving canonical path for ["
+          << resolvedPath << "]: " << _e.what() << "\n";
+    allowed = false;
+  }
+
+  if (!allowed)
+  {
+    gzerr << "Asset path [" << resolvedPath
+      << "] is not within the allowed resource paths. Access denied.\n";
+    sendAssetError("asset_access_denied");
+    return;
+  }
+
+  // Read the file
+  std::ifstream infile(canonicalResolved, std::ios_base::binary);
+
+  // weakly_canonical does not require the file to exist, so a path can pass
+  // the access check above and still fail to open here.
+  if (!infile.is_open())
+  {
+    gzerr << "Failed to open asset file [" << canonicalResolved
+          << "].\n";
+    sendAssetError("asset_not_found");
+    return;
+  }
+
+  std::string fileBuffer = std::string(
+      std::istreambuf_iterator<char>(infile),
+      std::istreambuf_iterator<char>());
+
+  // Do not send a partial/corrupt asset if an I/O error occurred mid-read.
+  if (infile.bad())
+  {
+    gzerr << "I/O error while reading asset file [" << canonicalResolved
+          << "].\n";
+    sendAssetError("asset_not_found");
+    return;
+  }
+
+  // Store the file in a protobuf message
+  gz::msgs::Bytes bytes;
+  bytes.set_data(fileBuffer);
+
+  // Construct the response message
+  std::string data = BUILD_MSG(this->operations[ASSET], assetUri,
+      bytes.GetTypeName(), bytes.SerializeAsString());
+
+  // Queue the message for delivery.
+  this->QueueMessage(this->connections[_socketId].get(),
+      data.c_str(), data.length());
 }
 
 //////////////////////////////////////////////////

--- a/plugins/websocket_server/WebsocketServer.cc
+++ b/plugins/websocket_server/WebsocketServer.cc
@@ -1100,8 +1100,9 @@ void WebsocketServer::OnAsset(int _socketId,
 
     gz::msgs::StringMsg msg;
     msg.set_data("asset_uri_missing");
-    std::string data = BUILD_MSG(this->operations[ASSET], "",
-        msg.GetTypeName(), msg.SerializeAsString());
+    std::string data =
+        BUILD_MSG(this->operations[ASSET], "", std::string(msg.GetTypeName()),
+                  msg.SerializeAsString());
 
     // Queue the message for delivery.
     this->QueueMessage(this->connections[_socketId].get(),


### PR DESCRIPTION
# 🦟 Bug fix

Part of gazebosim/gz-sim#3643

## Summary

This change mitigates a vulnerability where the websocket server allowed unprotected arbitrary file read access. The fix restricts reading of resources to assets residing strictly within the approved resource list or directory trees (canonicalized using std::filesystem::weakly_canonical).


## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the fix (as needed)
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [x] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Gemini-CLI

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

**Backports:** If this is a backport, please use **Rebase and Merge** instead.
